### PR TITLE
Added predict method, does not include baseline estimation

### DIFF
--- a/src/pybasic/pybasic.py
+++ b/src/pybasic/pybasic.py
@@ -6,6 +6,9 @@ Todo:
 from __future__ import annotations
 from typing import List, Tuple, Union, NamedTuple, Dict, Optional
 from enum import Enum
+import os
+from concurrent.futures import ThreadPoolExecutor
+from multiprocessing import cpu_count
 
 # import jax
 import jax.numpy as jnp
@@ -20,6 +23,17 @@ from pydantic import Field, BaseModel, PrivateAttr
 # from pybasic.tools.dct2d_tools import dct2d, idct2d
 # from pybasic.tools.inexact_alm import inexact_alm_rspca_l1
 
+# Get number of available threads to limit CPU thrashing
+# From preadator: https://pypi.org/project/preadator/
+if hasattr(os, "sched_getaffinity"):
+    # On Linux, we can detect how many cores are assigned to this process.
+    # This is especially useful when running in a Docker container, when the
+    # number of cores is intentionally limited.
+    NUM_THREADS = len(os.sched_getaffinity(0))
+else:
+    # Default back to multiprocessing cpu_count, which is always going to count
+    # the total number of cpus
+    NUM_THREADS = cpu_count()
 
 # Shorthand for common operations
 mm = jnp.matmul
@@ -84,6 +98,11 @@ class BaSiC(BaseModel):
         10,
         description="Maximum number of reweighting iterations.",
     )
+    max_workers: int = Field(
+        NUM_THREADS,
+        description="Maximum number of threads used for processing.",
+        exclude=True,  # Don't dump to output json/yaml
+    )
     optimization_tol: float = Field(
         1e-6,
         description="Optimization tolerance.",
@@ -122,6 +141,13 @@ class BaSiC(BaseModel):
             # TODO: sanity checks on device selection
             pass
 
+    def __call__(
+        self, images: np.ndarray, timelapse: bool = False
+    ) -> Union[Tuple[np.ndarray, np.ndarray], np.ndarray]:
+        """Shortcut for BaSiC.predict"""
+
+        return self.predict(images, timelapse)
+
     def fit(self, images: np.ndarray) -> None:
         """Generate illumination correction profiles.
 
@@ -149,12 +175,17 @@ class BaSiC(BaseModel):
     ) -> Union[Tuple[np.ndarray, np.ndarray], np.ndarray]:
         """Apply profile to images.
 
+        Todo:
+            Add in baseline/timelapse correction.
+
         Args:
             images: input images to correct
-            timelapse: calculate timelapse/photobleaching offsets
+            timelapse: calculate timelapse/photobleaching offsets. Currently
+                does nothing.
 
         Returns:
-            generator to apply illumination correction
+            An array of the same size as images. If timelapse is True, returns
+                a flat array of baseline corrections used in the calculations.
 
         Example:
             >>> basic.fit(images)
@@ -163,6 +194,8 @@ class BaSiC(BaseModel):
             ...     imsave(f"image_{i}.tif")
         """
 
+        im_float = images.astype(np.float64)
+
         # Initialize the output
         output = np.zeros(images.shape, dtype=images.dtype)
 
@@ -170,13 +203,28 @@ class BaSiC(BaseModel):
             # calculate timelapse from input series
             ...
 
-        def apply_profiles(im):
-            for prof in self.profiles:
-                im = prof.apply(im)
+        def unshade(ins, outs, i, dark, flat):
+            outs[..., i] = (ins[..., i] - dark) / flat
 
-        output = apply_profiles(images)
+        # If one or fewer workers, don't user ThreadPool. Useful for debugging.
+        if self.max_workers <= 1:
+            for i in range(images.shape[-1]):
+                unshade(im_float, output, i, self.darkfield, self.flatfield)
 
-        return output
+        else:
+            with ThreadPoolExecutor(self.max_workers) as executor:
+                threads = executor.map(
+                    lambda x: unshade(
+                        im_float, output, x, self.darkfield, self.flatfield
+                    ),
+                    range(images.shape[-1]),
+                )
+
+                # Get the result of each thread, this should catch thread errors
+                for thread in threads:
+                    assert thread is None
+
+        return output.astype(images.dtype)
 
     # REFACTOR large datasets will probably prefer saving corrected images to
     # files directly, a generator may be handy

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,4 +1,5 @@
 from pybasic import BaSiC
+import numpy as np
 
 
 # DEBUG fails because Settings is now a pydantic dataclass
@@ -14,3 +15,43 @@ def test_basic_verify_init():
 
 def test_basic():
     ...
+
+
+def test_basic_fit(capsys):
+
+    np.random.seed(42)  # answer to the meaning of life, should work here too
+
+    n_images = 8
+    basic = BaSiC(get_darkfield=False)
+
+    """Generate a parabolic gradient to simulate uneven illumination"""
+    # Create a gradient
+    size = basic.working_size
+    grid = np.meshgrid(*(2 * (np.linspace(-size // 2 + 1, size // 2, size),)))
+
+    # Create the gradient (flatfield) with and offset (darkfield)
+    gradient = sum(d ** 2 for d in grid) ** (1 / 2) + 8
+    gradient_int = gradient.astype(np.uint8)
+
+    # Ground truth, for correctness checking
+    truth = gradient / gradient.mean()
+
+    # Create an image stack and add poisson noise
+    images = np.random.poisson(lam=gradient_int.flatten(), size=(n_images, size ** 2))
+    images = images.transpose().reshape((size, size, n_images))
+
+    """Apply the shading model to the images"""
+    # flatfield only
+    basic.flatfield = gradient
+    corrected = basic.predict(images)
+    corrected_error = corrected.mean()
+    assert corrected_error < 0.5
+
+    # with darkfield correction
+    basic.darkfield = np.full(basic.flatfield.shape, 8)
+    corrected = basic.predict(images)
+    assert corrected.mean() < corrected_error
+
+    """Test shortcut"""
+    correct = basic(images)
+    assert corrected.mean() < corrected_error


### PR DESCRIPTION
This PR implements a simple predict function. It only uses the flatfield and darkfield components, with no baseline correction for now.

There is room for optimization here, since the unshading function always subtracts out the darkfield component. This does not alter the correctness of the output, because darkfield is initialized to zero and is left unchanged unless `BaSiC.get_darkfield==True`. However, subtracting 0s from each pixel likely increases the computation time, so we should change this in the future.

I also added in a `__call__` function, so you can do the following:
```python
basic = BaSiC()
basic.fit(images)

# these two lines produce the same result
corrected = basic.predict(images)
corrected = basic(images)
```