### PR TITLE
Solve jax version issue with colab

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -62,7 +62,7 @@ dev =
     flake8-pytest
     isort
     jax
-    jaxlib
+    jaxlib>=0.3.10 # to import jaxlib.xla_extension.XlaRuntimeError
     mypy
     nox
     opencv-python

--- a/src/basicpy/basicpy.py
+++ b/src/basicpy/basicpy.py
@@ -18,6 +18,9 @@ from multiprocessing import cpu_count
 from typing import Dict, Iterable, Optional, Tuple, Union
 
 import jax.numpy as jnp
+
+# FIXME change this to jax.xla.XlaRuntimeError
+# when https://github.com/google/jax/pull/10676 gets merged
 from jaxlib.xla_extension import XlaRuntimeError
 
 # 3rd party modules


### PR DESCRIPTION
Set the JAX version to `>=0.3.10` to import `jaxlib.xla_extension.XlaRuntimeError`.
Note `XlaRuntimeError` will be exposed to `jax` when https://github.com/google/jax/pull/10676 gets merged.
