### PR TITLE
Ignored language stat of jupyter notebook

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb linguist-documentation


### PR DESCRIPTION
Now the "languages" shows Jupyter as its main language. I think it's better to change this to Python for clarity.
Following:
https://stackoverflow.com/questions/19052834/is-it-possible-to-exclude-files-from-git-language-statistics

<img width="360" alt="image" src="https://user-images.githubusercontent.com/5919272/206130814-a10393b1-6287-4fde-a807-8ade0b423934.png">
