### PR TITLE
Remove upper JAX version limit

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,8 +26,8 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    jax>=0.3.10,<=0.3.23
-    jaxlib>=0.3.10,<=0.3.23 # to import jaxlib.xla_extension.XlaRuntimeError
+    jax>=0.3.10#,<=0.3.23
+    jaxlib>=0.3.10#,<=0.3.23 # to import jaxlib.xla_extension.XlaRuntimeError
     numpy
     pooch
     pydantic>=1.9.1


### PR DESCRIPTION
The JAX version had an upper limit, sometimes leading to installation problems. 
This PR tries to remove this constraint.