### PR TITLE
Update installation doc for mac M1

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ cd BaSiCPy
 pip install .
 ```
 
-### For Mac users with M1 chip
+### For Mac users with M1 / M2 chip
 
 BaSiCPy requires [`jax`](https://github.com/google/jax/),
 which has potential build issue with M1 chips.
@@ -63,7 +63,7 @@ One easiest solution is using [Miniforge](https://github.com/conda-forge/minifor
 as explained [here](https://github.com/google/jax/issues/5501).
 In the Miniforge environment, please try the following:
 ```bash
-pip install "jax[cpu]==0.3.22" jaxlib
+conda install -c conda-forge jax jaxlib
 pip install basicpy
 ```
 
@@ -77,7 +77,7 @@ pip install "jax[cpu]==0.3.14" -f https://whls.blob.core.windows.net/unstable/in
 pip install basicpy
 ```
 
-One may need to add 
+One may need to add
 ```python
 import jax
 jax.config.update('jax_platform_name', 'cpu')


### PR DESCRIPTION
According to https://github.com/peng-lab/napari-basicpy/issues/4 we update the installation doc for M1 mac.