### PR TITLE
Fix type validation for BaSiC autosegment field

### DIFF
--- a/src/basicpy/basicpy.py
+++ b/src/basicpy/basicpy.py
@@ -10,7 +10,7 @@ import time
 from enum import Enum
 from multiprocessing import cpu_count
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union, Callable
 
 import jax.numpy as jnp
 
@@ -116,7 +116,7 @@ class BaSiC(BaseModel):
     sparse_cost_darkfield: float = Field(
         0.01, description="Weight of the darkfield sparse term in the Lagrangian."
     )
-    autosegment: bool = Field(
+    autosegment: Union[bool, Callable[[np.ndarray], np.ndarray]] = Field(
         False,
         description="When not False, automatically segment the image before fitting."
         "When True, `threshold_otsu` from `scikit-image` is used "


### PR DESCRIPTION
Currently, passing a callable to the `autosegment` field of `BaSiC` results in the following exception:
```
ValidationError: 1 validation error for BaSiC
autosegment
  value could not be parsed to a boolean (type=type_error.bool)
```

Since the documentation states this field supports either a bool or callable, i'm guessing this is a bug.

This PR changes the validation to accept either bool or a callable which accepts and returns a single numpy array