### PR TITLE
Remove import of datasets module from top level

### DIFF
--- a/src/basicpy/__init__.py
+++ b/src/basicpy/__init__.py
@@ -3,7 +3,6 @@
 import logging
 import os
 
-from basicpy import datasets
 from basicpy.basicpy import BaSiC
 
 # Set logger level from environment variable
@@ -12,4 +11,4 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging_level)
 
 
-__all__ = ["BaSiC", "datasets", "metrics"]
+__all__ = ["BaSiC"]


### PR DESCRIPTION
Placing an import for the datasets module in the top level `__init__.py` file causes the sample datasets to be downloaded for every user of the code. Most users don't need the sample datasets, and in fact it can cause lots of extra overhead and other errors in containers (as the cached downloads are discarded after every run and the calling user may not even be able to write to the default cache directory). Removing this import line eliminates the problem and has no other effects on the functioning of the code. The test cases still correctly trigger the downloads when they import basicpy.datasets.  This change also cleans up `__all__`. 'datasets' no longer belongs there, and there was another symbol 'metrics' which is not even present.