### PR TITLE
Fix calculation of sparse_cost_darkfield

### DIFF
--- a/src/basicpy/basicpy.py
+++ b/src/basicpy/basicpy.py
@@ -401,7 +401,7 @@ class BaSiC(BaseModel):
             self._smoothness_darkfield = self.smoothness_darkfield
         if self.sparse_cost_darkfield is None:
             self._sparse_cost_darkfield = (
-                self._smoothness_darkfield * self.sparse_cost_darkfield * 100
+                self._smoothness_darkfield * 0.01 * 100
             )
         else:
             self._sparse_cost_darkfield = self.sparse_cost_darkfield


### PR DESCRIPTION
if sparse_cost_darkfield is None, it should use default value 0.01